### PR TITLE
feat(account): create account settings and change password in the dashboard

### DIFF
--- a/src/app/[locale]/(profile)/_components/profile-sidebar.tsx
+++ b/src/app/[locale]/(profile)/_components/profile-sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LogOut, Lock, UserPen } from "lucide-react";
@@ -10,12 +11,12 @@ import { signOut } from "next-auth/react";
 import { toast } from "sonner";
 
 export default function ProfileSidebar() {
+  // Translation
+  const t = useTranslations("profile");
+
   // Routing
   const pathname = usePathname();
   const router = useRouter();
-
-  // Translation
-  const t = useTranslations("profile");
 
   // Get pathname without locale
   const cleanedPathname = pathname.replace(/^\/(en|ar)/, "");
@@ -38,8 +39,8 @@ export default function ProfileSidebar() {
 
   return (
     <section>
-      <h1 className="capitalize text-5xl font-bold text-zinc-800 mb-9">{t("update-profile")}</h1>
-      <nav className="flex flex-col gap-4 min-h-[66vh] bg-zinc-50 border border-zinc-100 rounded-lg p-4">
+      <h1 className="capitalize text-5xl font-bold text-zinc-800 dark:text-zinc-50 mb-9">{t("update-profile")}</h1>
+      <nav className="flex flex-col gap-4 min-h-[66vh] bg-zinc-50 border border-zinc-100 dark:bg-zinc-800 dark:border-zinc-800 rounded-lg p-4">
         {links.map(({ href, label, icon: Icon }) => (
           <Link
             key={href}
@@ -47,8 +48,8 @@ export default function ProfileSidebar() {
             className={cn(
               "flex items-center gap-2 px-3 py-2 rounded-md text-base font-medium transition-colors",
               cleanedPathname === href
-                ? "bg-zinc-800 text-white"
-                : "text-zinc-800 hover:bg-zinc-800 hover:text-white"
+                ? "bg-zinc-800 text-white dark:bg-zinc-600"
+                : "text-zinc-800 hover:bg-zinc-800 hover:text-white dark:text-zinc-50 dark:hover:bg-zinc-600"
             )}
           >
             <Icon className="w-4 h-4" />
@@ -60,7 +61,7 @@ export default function ProfileSidebar() {
           <Button
           variant="ghost"
           className="flex items-center justify-start gap-2 w-full rounded-md px-3 py-2 text-base font-medium 
-            text-maroon-500 bg-zinc-100 hover:bg-red-50 hover:text-maroon-600 transition-colors mt-auto "
+            text-maroon-500 bg-zinc-100 hover:bg-red-50 hover:text-maroon-600 transition-colors mt-auto dark:bg-zinc-600 "
           onClick={handleLogout}
           >
           <LogOut className="w-4 h-4" />

--- a/src/app/[locale]/(profile)/_components/profile-sidebar.tsx
+++ b/src/app/[locale]/(profile)/_components/profile-sidebar.tsx
@@ -1,0 +1,72 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { LogOut, Lock, UserPen } from "lucide-react";
+import { cn } from "@lib/utils/cn.util";
+import { Button } from "@components/ui/button";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@i18n/navigation";
+import { signOut } from "next-auth/react";
+import { toast } from "sonner";
+
+export default function ProfileSidebar() {
+  // Routing
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Translation
+  const t = useTranslations("profile");
+
+  // Get pathname without locale
+  const cleanedPathname = pathname.replace(/^\/(en|ar)/, "");
+
+  const links = [
+    { href: "/profile", label: t("my-account"), icon: UserPen },
+    { href: "/change-password", label: t("change-password"), icon: Lock },
+  ];
+
+  // Logout function
+  const handleLogout = async () => {
+    try {
+      await signOut({ redirect: false }); // sign out without automatic redirect
+      toast.success(t("logged-out-successfully")); // show toast
+      router.push("/login"); // redirect to login page
+    } catch (error) {
+      toast.error(t("logout-failed")); // show error toast if failed
+    }
+  };
+
+  return (
+    <section>
+      <h1 className="capitalize text-5xl font-bold text-zinc-800 mb-9">{t("update-profile")}</h1>
+      <nav className="flex flex-col gap-4 min-h-[66vh] bg-zinc-50 border border-zinc-100 rounded-lg p-4">
+        {links.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              "flex items-center gap-2 px-3 py-2 rounded-md text-base font-medium transition-colors",
+              cleanedPathname === href
+                ? "bg-zinc-800 text-white"
+                : "text-zinc-800 hover:bg-zinc-800 hover:text-white"
+            )}
+          >
+            <Icon className="w-4 h-4" />
+            {label}
+          </Link>
+        ))}
+
+        {/* Logout button */}
+          <Button
+          variant="ghost"
+          className="flex items-center justify-start gap-2 w-full rounded-md px-3 py-2 text-base font-medium 
+            text-maroon-500 bg-zinc-100 hover:bg-red-50 hover:text-maroon-600 transition-colors mt-auto "
+          onClick={handleLogout}
+          >
+          <LogOut className="w-4 h-4" />
+            {t("logout")}
+          </Button>
+      </nav>
+    </section>
+  );
+}

--- a/src/app/[locale]/(profile)/change-password/page.tsx
+++ b/src/app/[locale]/(profile)/change-password/page.tsx
@@ -1,0 +1,8 @@
+import ChangePasswordForm from '@components/shared/change-password-form'
+import React from 'react'
+
+export default function ChangePasswordPage() {
+  return (
+   <ChangePasswordForm />
+  )
+}

--- a/src/app/[locale]/(profile)/layout.tsx
+++ b/src/app/[locale]/(profile)/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import "@app/globals.css"
+import ProfileSidebar from "./_components/profile-sidebar";
+
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="container mx-auto flex gap-6 py-8">
+      {/* Sidebar */}
+      <aside className="w-1/4">
+        <ProfileSidebar />
+      </aside>
+
+      {/* Main content */}
+      <main className="w-3/4 p-4 mt-9">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/[locale]/(profile)/layout.tsx
+++ b/src/app/[locale]/(profile)/layout.tsx
@@ -1,20 +1,30 @@
 import { ReactNode } from "react";
 import "@app/globals.css"
 import ProfileSidebar from "./_components/profile-sidebar";
-
+import Header from "@components/layout/header";
+import Footer from "@components/layout/footer";
 
 export default function ProfileLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="container mx-auto flex gap-6 py-8">
-      {/* Sidebar */}
-      <aside className="w-1/4">
-        <ProfileSidebar />
-      </aside>
+    <main className="flex min-h-screen flex-col">
+      <Header />
 
-      {/* Main content */}
-      <main className="w-3/4 p-4 mt-9">
-        {children}
-      </main>
-    </div>
+      {/* Wrapper for sidebar + content */}
+      <div className="container mx-auto flex gap-6 py-8 flex-1">
+        
+        {/* Sidebar */}
+        <aside className="w-1/4">
+          <ProfileSidebar />
+        </aside>
+
+        {/* Main content */}
+        <div className="w-3/4 p-4">
+          {children}
+        </div>
+
+      </div>
+
+      <Footer />
+    </main>
   );
 }

--- a/src/app/[locale]/(profile)/profile/page.tsx
+++ b/src/app/[locale]/(profile)/profile/page.tsx
@@ -1,0 +1,9 @@
+import ProfileForm from '@components/shared/account-form';
+import { getProfileData } from '@lib/actions/profile/profile.action';
+
+export default async function ProfilePage() {
+   const profile = await getProfileData();
+  return (
+    <ProfileForm profile= {profile} showChangePassword={false}  /> 
+  )
+}

--- a/src/app/[locale]/dashboard/_components/account-form.tsx
+++ b/src/app/[locale]/dashboard/_components/account-form.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { useEffect } from "react";
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@components/ui/form";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
+import { ProfileFormValues } from "@lib/types/profile/profile";
+import { useUpdateProfile } from "@/hooks/profile/use-update-profile.hook";
+import { getProfileData } from "@lib/actions/profile/profile.action";
+import AvatarUpload from "@components/shared/avatar-upload";
+import DeleteAccountSection from "@components/shared/delete-account-btn";
+import Link from "next/link";
+
+interface ProfileFormProps {
+  profile: ProfileFormValues;
+}
+
+/**
+ * ProfileForm Component
+ * 
+ * Displays a form to view and update user's profile information.
+ * Includes fields for avatar, first name, last name, email, phone, and gender.
+ * Also provides buttons for deleting the account and changing the password.
+ */
+
+export default function ProfileForm({ profile }: ProfileFormProps) {
+    // Initialize react-hook-form with default values from the profile
+  const form = useForm<ProfileFormValues>({
+    defaultValues: profile,
+  });
+
+  // Hook for updating the profile
+    const updateProfile = useUpdateProfile();
+
+    //Handle form submission
+function onSubmit(values: ProfileFormValues) {
+  updateProfile.mutate(values, {
+    onSuccess: (data) => {
+      // Reset form with updated user data after successful update
+      form.reset(data.user);
+    },
+  });
+}
+
+  return (
+    <FormProvider {...form}>
+      <form className="space-y-6 bg-white rounded-2xl p-6" onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          name="photo"
+          control={form.control}
+          render={({ field }) => (
+            <AvatarUpload value={field.value} onChange={(url) => field.onChange(url)} />
+          )}
+        />
+        <div className="flex gap-4 justify-between">
+          {/* first name */}
+          <div className="flex-1">
+          <FormField name="firstName" control={form.control} render={({ field }) => (
+            <FormItem>
+              <FormLabel>First Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          </div>
+
+          {/* last name */}
+         <div className="flex-1">
+          <FormField name="lastName" control={form.control} render={({ field }) => (
+            <FormItem>
+              <FormLabel>Last Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+        </div>
+        </div>
+
+        {/* email */}
+        <FormField name="email" control={form.control} render={({ field }) => (
+          <FormItem>
+            <FormLabel>Email</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )} />
+  {/* phone */}
+        <FormField name="phone" control={form.control} render={({ field }) => (
+          <FormItem>
+            <FormLabel>Phone</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )} />
+
+        {/* gender */}
+        <FormField name="gender" control={form.control} render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-zinc-400">Gender</FormLabel>
+            <FormControl>
+              <Input className="text-zinc-400" {...field} disabled readOnly />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )} />
+
+        {/* Form footer (buttons) */}
+        <div className="flex justify-between">
+          <div className="flex-1">
+        <DeleteAccountSection />
+        <Button variant="link" className="mt-16 capitalize text-base p-0">
+          <Link href="change-password">Change Password</Link>
+        </Button>
+        </div>
+
+          <div className="flex-1 flex justify-end">
+            <Button type="submit" className="mt-16 capitalize text-base">Save Changes</Button>
+          </div>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/app/[locale]/dashboard/_components/account-form.tsx
+++ b/src/app/[locale]/dashboard/_components/account-form.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useForm, FormProvider } from "react-hook-form";
-import { useEffect } from "react";
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@components/ui/form";
 import { Input } from "@components/ui/input";
 import { Button } from "@components/ui/button";
 import { ProfileFormValues } from "@lib/types/profile/profile";
 import { useUpdateProfile } from "@/hooks/profile/use-update-profile.hook";
-import { getProfileData } from "@lib/actions/profile/profile.action";
 import AvatarUpload from "@components/shared/avatar-upload";
 import DeleteAccountSection from "@components/shared/delete-account-btn";
 import Link from "next/link";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 
 interface ProfileFormProps {
   profile: ProfileFormValues;
@@ -25,6 +25,9 @@ interface ProfileFormProps {
  */
 
 export default function ProfileForm({ profile }: ProfileFormProps) {
+    // Translation
+    const t = useTranslations("profile");
+
     // Initialize react-hook-form with default values from the profile
   const form = useForm<ProfileFormValues>({
     defaultValues: profile,
@@ -38,6 +41,7 @@ function onSubmit(values: ProfileFormValues) {
   updateProfile.mutate(values, {
     onSuccess: (data) => {
       // Reset form with updated user data after successful update
+      toast.success(t("profile-updated-successfully"));
       form.reset(data.user);
     },
   });
@@ -58,7 +62,7 @@ function onSubmit(values: ProfileFormValues) {
           <div className="flex-1">
           <FormField name="firstName" control={form.control} render={({ field }) => (
             <FormItem>
-              <FormLabel>First Name</FormLabel>
+              <FormLabel>{t("first-name")}</FormLabel>
               <FormControl>
                 <Input {...field} />
               </FormControl>
@@ -71,7 +75,7 @@ function onSubmit(values: ProfileFormValues) {
          <div className="flex-1">
           <FormField name="lastName" control={form.control} render={({ field }) => (
             <FormItem>
-              <FormLabel>Last Name</FormLabel>
+              <FormLabel>{t("last-name")}</FormLabel>
               <FormControl>
                 <Input {...field} />
               </FormControl>
@@ -84,7 +88,7 @@ function onSubmit(values: ProfileFormValues) {
         {/* email */}
         <FormField name="email" control={form.control} render={({ field }) => (
           <FormItem>
-            <FormLabel>Email</FormLabel>
+            <FormLabel>{t("email")}</FormLabel>
             <FormControl>
               <Input {...field} />
             </FormControl>
@@ -94,7 +98,7 @@ function onSubmit(values: ProfileFormValues) {
   {/* phone */}
         <FormField name="phone" control={form.control} render={({ field }) => (
           <FormItem>
-            <FormLabel>Phone</FormLabel>
+            <FormLabel>{t("phone")}</FormLabel>
             <FormControl>
               <Input {...field} />
             </FormControl>
@@ -105,7 +109,7 @@ function onSubmit(values: ProfileFormValues) {
         {/* gender */}
         <FormField name="gender" control={form.control} render={({ field }) => (
           <FormItem>
-            <FormLabel className="text-zinc-400">Gender</FormLabel>
+            <FormLabel className="text-zinc-400">{t("gender")}</FormLabel>
             <FormControl>
               <Input className="text-zinc-400" {...field} disabled readOnly />
             </FormControl>
@@ -118,12 +122,12 @@ function onSubmit(values: ProfileFormValues) {
           <div className="flex-1">
         <DeleteAccountSection />
         <Button variant="link" className="mt-16 capitalize text-base p-0">
-          <Link href="change-password">Change Password</Link>
+          <Link href="change-password">{t("change-password")}</Link>
         </Button>
         </div>
 
           <div className="flex-1 flex justify-end">
-            <Button type="submit" className="mt-16 capitalize text-base">Save Changes</Button>
+            <Button type="submit" className="mt-16 capitalize text-base">{t("save-changes")}</Button>
           </div>
         </div>
       </form>

--- a/src/app/[locale]/dashboard/account/page.tsx
+++ b/src/app/[locale]/dashboard/account/page.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import ProfileForm from "../_components/account-form";
+import { getProfileData } from "@lib/actions/profile/profile.action";
+
+
+export default async function page() {
+
+  // Fetching form data 
+  const profile = await getProfileData();
+  return (
+    <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
+        <div className="w-1/4">
+            <h1>Placeholder...</h1>
+        </div>
+        <div className="w-3/4 p-4 mt-9 ">
+            <h1 className="text-zinc-800 text-2xl font-semibold capitalize">Account Settings</h1>
+            <ProfileForm profile= {profile} />
+        </div>
+    </div>
+  )
+}

--- a/src/app/[locale]/dashboard/account/page.tsx
+++ b/src/app/[locale]/dashboard/account/page.tsx
@@ -12,13 +12,13 @@ export default async function AccountPage() {
   const profile = await getProfileData();
 
   return (
-    <div className="bg-zinc-50 min-h-screen">
+    <div className="bg-zinc-50 min-h-screen dark:bg-zinc-900">
       <div className="container mx-auto flex gap-6 py-8 ">
         <div className="w-1/4">
           <h1>Placeholder...</h1>
         </div>
         <div className="w-3/4 p-4">
-          <h1 className="text-zinc-800 text-2xl font-semibold capitalize mb-9">{t("account-settings")}</h1>
+          <h1 className="text-zinc-800 text-2xl font-semibold capitalize mb-9 dark:text-zinc-50">{t("account-settings")}</h1>
           <ProfileForm profile= {profile} showChangePassword= {true} />
         </div>
       </div>

--- a/src/app/[locale]/dashboard/account/page.tsx
+++ b/src/app/[locale]/dashboard/account/page.tsx
@@ -1,19 +1,23 @@
 import React from "react";
 import ProfileForm from "../_components/account-form";
 import { getProfileData } from "@lib/actions/profile/profile.action";
+import { getTranslations } from "next-intl/server";
 
 
-export default async function page() {
+export default async function AccountPage() {
+  // Translation
+  const t = await getTranslations("profile");
 
   // Fetching form data 
   const profile = await getProfileData();
+
   return (
     <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
         <div className="w-1/4">
             <h1>Placeholder...</h1>
         </div>
         <div className="w-3/4 p-4 mt-9 ">
-            <h1 className="text-zinc-800 text-2xl font-semibold capitalize">Account Settings</h1>
+            <h1 className="text-zinc-800 text-2xl font-semibold capitalize">{t("account-settings")}</h1>
             <ProfileForm profile= {profile} />
         </div>
     </div>

--- a/src/app/[locale]/dashboard/account/page.tsx
+++ b/src/app/[locale]/dashboard/account/page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ProfileForm from "../_components/account-form";
+import ProfileForm from "../../../../components/shared/account-form";
 import { getProfileData } from "@lib/actions/profile/profile.action";
 import { getTranslations } from "next-intl/server";
 
@@ -12,14 +12,16 @@ export default async function AccountPage() {
   const profile = await getProfileData();
 
   return (
-    <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
+    <div className="bg-zinc-50 min-h-screen">
+      <div className="container mx-auto flex gap-6 py-8 ">
         <div className="w-1/4">
-            <h1>Placeholder...</h1>
+          <h1>Placeholder...</h1>
         </div>
-        <div className="w-3/4 p-4 mt-9 ">
-            <h1 className="text-zinc-800 text-2xl font-semibold capitalize">{t("account-settings")}</h1>
-            <ProfileForm profile= {profile} />
+        <div className="w-3/4 p-4">
+          <h1 className="text-zinc-800 text-2xl font-semibold capitalize mb-9">{t("account-settings")}</h1>
+          <ProfileForm profile= {profile} showChangePassword= {true} />
         </div>
+      </div>
     </div>
   )
 }

--- a/src/app/[locale]/dashboard/change-password/page.tsx
+++ b/src/app/[locale]/dashboard/change-password/page.tsx
@@ -1,0 +1,21 @@
+import ChangePasswordForm from "@components/shared/change-password-form";
+import { useTranslations } from "next-intl";
+import React from "react";
+
+
+export default function page() {
+    // Translation
+    const t = useTranslations("change-password");
+    return (
+        <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
+            <div className="w-1/4">
+                <h1>Placeholder...</h1>
+            </div>
+            <div className="w-3/4 p-4 mt-9 bg-white rounded-2xl">
+                <h1 className="text-zinc-800 text-2xl font-semibold capitalize">{t("change-password")}</h1>
+                <ChangePasswordForm />
+            </div>
+        </div>
+    );
+}
+

--- a/src/app/[locale]/dashboard/change-password/page.tsx
+++ b/src/app/[locale]/dashboard/change-password/page.tsx
@@ -7,12 +7,12 @@ export default function ChangePasswordPage() {
     const t = useTranslations("change-password");
 
     return (
-        <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
+        <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen dark:bg-zinc-900">
             <div className="w-1/4">
                 <h1>Placeholder...</h1>
             </div>
-            <div className="w-3/4 p-4 mt-9 bg-white rounded-2xl">
-                <h1 className="text-zinc-800 text-2xl font-semibold capitalize">{t("change-password")}</h1>
+            <div className="w-3/4 p-4 mt-9 bg-white dark:bg-zinc-800 rounded-2xl">
+                <h1 className="text-zinc-800 dark:text-zinc-50 text-2xl font-semibold capitalize">{t("change-password")}</h1>
                 <ChangePasswordForm />
             </div>
         </div>

--- a/src/app/[locale]/dashboard/change-password/page.tsx
+++ b/src/app/[locale]/dashboard/change-password/page.tsx
@@ -2,10 +2,10 @@ import ChangePasswordForm from "@components/shared/change-password-form";
 import { useTranslations } from "next-intl";
 import React from "react";
 
-
-export default function page() {
+export default function ChangePasswordPage() {
     // Translation
     const t = useTranslations("change-password");
+
     return (
         <div className="container mx-auto flex gap-6 py-8 bg-zinc-50 min-h-screen">
             <div className="w-1/4">

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+
+export default function page() {
+    return (
+        <div className="min-h-screen bg-zinc-50">
+           dashboard
+        </div>
+    );
+}

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-export default function ProfilePage() {
-  return (
-    <div>PROFILE</div>
-  )
-}

--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -1,0 +1,38 @@
+// app/api/delete-account/route.ts
+import { NextResponse } from "next/server";
+import { getDecodeToken } from "@/lib/utils/get-decode-token";
+
+export async function DELETE() {
+  const token = await getDecodeToken();
+
+  if (!token?.accessToken) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const res = await fetch(`${process.env.BASE_URL}auth/deleteMe`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token.accessToken}`,
+        },
+      }
+    );
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: data.message || "Failed to delete account" },
+        { status: res.status }
+      );
+    }
+
+    return NextResponse.json({ message: "Account deleted successfully" });
+  } catch (err) {
+    return NextResponse.json(
+      { message: "Something went wrong" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/update-profile/route.ts
+++ b/src/app/api/update-profile/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getDecodeToken } from "@lib/utils/get-decode-token";
+
+export async function PUT(req: Request) {
+
+  // Step 1: Read & parse incoming JSON request body
+  const body = await req.json();
+
+  // Step 2: Get and validate authenticated user token
+  const token = await getDecodeToken();
+  // If no token → return Unauthorized response
+  if (!token?.accessToken) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  // =======================================================
+  // Step 3: Filter ONLY the fields allowed to be updated
+  // This protects backend from receiving unwanted fields
+  // like _id, photo, role, createdAt, wishlist, addresses
+  // =======================================================
+  const allowedFields = ["firstName", "lastName", "email", "phone"];
+  const filteredBody: any = {};
+
+  // Loop through allowed fields and copy only the existing ones
+  for (const key of allowedFields) {
+    if (body[key] !== undefined) {
+      filteredBody[key] = body[key];
+    }
+  }
+
+  // Step 4: Send sanitized body to backend API
+  const res = await fetch(`${process.env.BASE_URL}auth/editProfile`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token.accessToken}`,
+    },
+    body: JSON.stringify(filteredBody),
+  });
+
+  // Step 5: Parse backend response
+  const data = await res.json();
+
+  // Step 6: If backend returned an error → forward it
+  if (!res.ok) {
+    return NextResponse.json({ message: data.message }, { status: res.status });
+  }
+
+  // Step 7: Successfully updated → return backend response
+  return NextResponse.json(data);
+}

--- a/src/app/api/upload-photo/route.ts
+++ b/src/app/api/upload-photo/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getDecodeToken } from "@lib/utils/get-decode-token";
+
+export async function PUT(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("photo") as File;
+
+    if (!file) {
+      return NextResponse.json(
+        { message: "No file uploaded" },
+        { status: 400 }
+      );
+    }
+
+    // Decode token from cookies (Server only)
+    const token = await getDecodeToken();
+
+    if (!token) {
+      return NextResponse.json(
+        { message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // Re-create file as Node.js File for backend
+    const arrayBuffer = await file.arrayBuffer();
+    const nodeFile = new File([arrayBuffer], file.name, {
+      type: file.type,
+      lastModified: Date.now(),
+    });
+
+    const backendForm = new FormData();
+    backendForm.append("photo", nodeFile);
+
+    // Forward request to real backend API
+    const res = await fetch(`${process.env.BASE_URL}auth/upload-photo`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token.accessToken}`,
+      },
+      body: backendForm,
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: data.message || "Upload failed", data },
+        { status: res.status }
+      );
+    }
+
+    return NextResponse.json(data);
+
+  } catch (error) {
+    console.error("Upload route error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/shared/account-form.tsx
+++ b/src/components/shared/account-form.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from "next-intl";
 
 interface ProfileFormProps {
   profile: ProfileFormValues;
+  showChangePassword?: boolean;
 }
 
 /**
@@ -24,7 +25,7 @@ interface ProfileFormProps {
  * Also provides buttons for deleting the account and changing the password.
  */
 
-export default function ProfileForm({ profile }: ProfileFormProps) {
+export default function ProfileForm({ profile, showChangePassword = true }: ProfileFormProps) {
     // Translation
     const t = useTranslations("profile");
 
@@ -95,7 +96,8 @@ function onSubmit(values: ProfileFormValues) {
             <FormMessage />
           </FormItem>
         )} />
-  {/* phone */}
+
+        {/* phone */}
         <FormField name="phone" control={form.control} render={({ field }) => (
           <FormItem>
             <FormLabel>{t("phone")}</FormLabel>
@@ -120,15 +122,25 @@ function onSubmit(values: ProfileFormValues) {
         {/* Form footer (buttons) */}
         <div className="flex justify-between">
           <div className="flex-1">
+        {/* Delete Button */}
         <DeleteAccountSection />
-        <Button variant="link" className="mt-16 capitalize text-base p-0">
-          <Link href="change-password">{t("change-password")}</Link>
-        </Button>
+
+        {/* Change Password button
+            - Display this button only in the Dashboard Account page
+            - Do NOT display in the App Profile page
+            Controlled via `showChangePassword` prop
+        */}
+        {showChangePassword && (
+          <Button variant="link" className="mt-16 capitalize text-base p-0">
+            <Link href="change-password">{t("change-password")}</Link>
+          </Button>
+        )}
         </div>
 
-          <div className="flex-1 flex justify-end">
-            <Button type="submit" className="mt-16 capitalize text-base">{t("save-changes")}</Button>
-          </div>
+        {/* Save form changes Button */}
+        <div className="flex-1 flex justify-end">
+          <Button type="submit" className="mt-16 capitalize text-base">{t("save-changes")}</Button>
+        </div>
         </div>
       </form>
     </FormProvider>

--- a/src/components/shared/account-form.tsx
+++ b/src/components/shared/account-form.tsx
@@ -50,7 +50,7 @@ function onSubmit(values: ProfileFormValues) {
 
   return (
     <FormProvider {...form}>
-      <form className="space-y-6 bg-white rounded-2xl p-6" onSubmit={form.handleSubmit(onSubmit)}>
+      <form className="space-y-6 bg-white dark:bg-zinc-800 rounded-2xl p-6" onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           name="photo"
           control={form.control}

--- a/src/components/shared/avatar-upload.tsx
+++ b/src/components/shared/avatar-upload.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { Camera, CloudUpload, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+type AvatarUploadProps = {
+  value: string;
+  onChange: (val: string) => void;
+};
+
+export default function AvatarUpload({ value, onChange }: AvatarUploadProps) {
+  const [isUploading, setIsUploading] = useState(false);
+  
+
+  const handleUpload = async (file: File) => {
+    const formData = new FormData();
+    formData.append("photo", file);
+
+    try {
+      setIsUploading(true);
+
+      const res = await fetch("/api/upload-photo", {
+        method: "PUT",
+        body: formData,
+      });
+
+      const data = await res.json();
+
+      // ✅ Check JSON response
+      if (!res.ok || data.status !== "success") {
+        console.error("Upload failed", data);
+        toast.error(data.message || "Failed to upload photo");
+        return;
+      }
+
+      // Update value
+      onChange(data.data.url);
+
+      // ✅ Show success toast
+      toast.success("Profile photo updated successfully!");
+
+    } catch (err) {
+      console.error("Upload failed:", err);
+      toast.error("Failed to upload photo");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const onFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    handleUpload(file);
+  };
+
+  return (
+    <div className="flex items-center gap-6">
+      <div className="relative">
+        {/* Avatar Preview */}
+        <img
+          src={value || "/default-avatar.png"}
+          alt="profile"
+          className="w-28 h-28 rounded-full object-cover border"
+        />
+
+        {/* Upload Button */}
+        <label
+          htmlFor="avatar-upload"
+          className="absolute bottom-0 right-0 bg-zinc-50 text-zinc-800 text-xs px-2 py-1 rounded-full cursor-pointer"
+        >
+          {isUploading ? (
+            <Loader2 className="animate-spin w-4 h-4" />
+          ) : (
+             <CloudUpload size={18} stroke="#27272A" /> 
+          )}
+        </label>
+
+        <input
+          id="avatar-upload"
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={onFileSelect}
+        />
+      </div>
+       <div>
+              <h2 className="text-lg font-semibold">Upload Photo</h2>
+              <p className="text-sm text-gray-500">
+                You can upload a .jpg, .png, or .gif photo with max size of 5MB.
+              </p>
+            </div>
+    </div>
+  );
+}

--- a/src/components/shared/avatar-upload.tsx
+++ b/src/components/shared/avatar-upload.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Camera, CloudUpload, Loader2 } from "lucide-react";
+import { CloudUpload, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 
 type AvatarUploadProps = {
   value: string;
@@ -10,6 +11,9 @@ type AvatarUploadProps = {
 };
 
 export default function AvatarUpload({ value, onChange }: AvatarUploadProps) {
+  // Translation
+  const t = useTranslations("profile");
+
   const [isUploading, setIsUploading] = useState(false);
   
 
@@ -85,9 +89,9 @@ export default function AvatarUpload({ value, onChange }: AvatarUploadProps) {
         />
       </div>
        <div>
-              <h2 className="text-lg font-semibold">Upload Photo</h2>
+              <h2 className="text-lg font-semibold">{t("upload-photo")}</h2>
               <p className="text-sm text-gray-500">
-                You can upload a .jpg, .png, or .gif photo with max size of 5MB.
+                {t("upload-text")}
               </p>
             </div>
     </div>

--- a/src/components/shared/change-password-form.tsx
+++ b/src/components/shared/change-password-form.tsx
@@ -1,0 +1,140 @@
+// src/components/dashboard/forms/ChangePasswordForm.tsx
+"use client";
+
+import { Form, FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Label } from "@components/ui/label";
+import { cn } from "@lib/utils/cn.util";
+import { PasswordInput } from "@components/shared/password-input";
+import { Button } from "@components/ui/button";
+import { useTranslations } from "next-intl";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@components/ui/form";
+import { Input } from "@components/ui/input";
+import { toast } from "sonner";
+import { useChangePassword } from "@/hooks/profile/use-change-password.hook";
+import { FormInput } from "@lib/types/profile/change-password";
+import { changePassword } from "@lib/actions/profile/change-password.action";
+import { ChangePasswordFormSchema, ChangePasswordValues } from "@lib/schemas/profile/change-password.schema";
+
+export default function ChangePasswordForm() {
+  // Translation
+  const t = useTranslations("change-password");
+
+  // Hooks
+  const { mutate, isPending } = useChangePassword();
+
+   // Form hook
+    const form = useForm<ChangePasswordValues>({
+        resolver: zodResolver(ChangePasswordFormSchema),
+        mode: "onSubmit",
+
+        defaultValues: {
+            password: "",
+            newPassword: "",
+            confirmNewPassword: "",
+        },
+    });
+
+    // Function 
+    const onSubmit = async (data: FormInput<typeof ChangePasswordFormSchema>) => { 
+    try {
+      await changePassword({
+        password: data.password,
+        newPassword: data.newPassword,
+        });
+      // Show success toast
+      toast.success(t("password-updated-successfully"));
+      form.reset();
+
+    } catch (err) {
+      // Show error toast
+      const error = err as Error;
+      toast.error(error.message || t("failed-update-password"));
+
+    }
+  };
+
+return (
+  <div>
+    {/* Password form */}
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit((values) => onSubmit(values))}
+        className="space-y-6"
+      >
+        {/* Current Password */}
+        <FormField
+          name="password"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem className="border-b-1 py-6 dark:border-b-zinc-800">
+              <FormLabel className="text-base font-medium">{t("old-password")}</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="password"
+                  placeholder="••••••••"
+                  aria-invalid={!!form.formState.errors.password}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* New Password */}
+        <FormField
+          name="newPassword"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-base font-medium">{t("new-password")}</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="password"
+                  placeholder="••••••••"
+                  aria-invalid={!!form.formState.errors.newPassword}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Confirm New Password */}
+        <FormField
+          name="confirmNewPassword"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-base font-medium">{t("confirm-new-password")}</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="password"
+                  placeholder="••••••••"
+                  aria-invalid={!!form.formState.errors.confirmNewPassword}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Submit Button */}
+        <div className="w-full text-right">
+          <Button
+            type="submit"
+            className="font-medium text-base text-white mt-12"
+            disabled={isPending}
+          >
+            {isPending ? t("updating") : t("change-password")}   
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  </div>
+);
+}
+

--- a/src/components/shared/change-password-form.tsx
+++ b/src/components/shared/change-password-form.tsx
@@ -1,12 +1,8 @@
 // src/components/dashboard/forms/ChangePasswordForm.tsx
 "use client";
 
-import { Form, FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Label } from "@components/ui/label";
-import { cn } from "@lib/utils/cn.util";
-import { PasswordInput } from "@components/shared/password-input";
-import { Button } from "@components/ui/button";
 import { useTranslations } from "next-intl";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@components/ui/form";
 import { Input } from "@components/ui/input";
@@ -15,6 +11,9 @@ import { useChangePassword } from "@/hooks/profile/use-change-password.hook";
 import { FormInput } from "@lib/types/profile/change-password";
 import { changePassword } from "@lib/actions/profile/change-password.action";
 import { ChangePasswordFormSchema, ChangePasswordValues } from "@lib/schemas/profile/change-password.schema";
+import { Button } from "@components/ui/button";
+import { signOut } from "next-auth/react";
+import { useRouter } from "@i18n/navigation";
 
 export default function ChangePasswordForm() {
   // Translation
@@ -22,6 +21,9 @@ export default function ChangePasswordForm() {
 
   // Hooks
   const { mutate, isPending } = useChangePassword();
+
+  // Routing
+  const router = useRouter();
 
    // Form hook
     const form = useForm<ChangePasswordValues>({
@@ -45,6 +47,12 @@ export default function ChangePasswordForm() {
       // Show success toast
       toast.success(t("password-updated-successfully"));
       form.reset();
+
+      // 1- Logout
+      await signOut({ redirect: false }); 
+
+      // 2- Redirect to homepage
+      router.push("/login");
 
     } catch (err) {
       // Show error toast

--- a/src/components/shared/delete-account-btn.tsx
+++ b/src/components/shared/delete-account-btn.tsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import DeleteAccountModal from "./delete-modal";
+
+export default function DeleteAccountSection() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button 
+        variant="link" 
+        className="mt-16 capitalize text-red-600 text-base p-0"
+        onClick={() => setOpen(true)}
+      >
+        Delete my account
+      </Button>
+
+      <DeleteAccountModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/src/components/shared/delete-account-btn.tsx
+++ b/src/components/shared/delete-account-btn.tsx
@@ -1,8 +1,12 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import DeleteAccountModal from "./delete-modal";
+import { useTranslations } from "next-intl";
 
 export default function DeleteAccountSection() {
+  // Translation
+  const t = useTranslations("profile");
+
   const [open, setOpen] = useState(false);
 
   return (
@@ -12,7 +16,7 @@ export default function DeleteAccountSection() {
         className="mt-16 capitalize text-red-600 text-base p-0"
         onClick={() => setOpen(true)}
       >
-        Delete my account
+        {t("delete-my-account")}
       </Button>
 
       <DeleteAccountModal open={open} onOpenChange={setOpen} />

--- a/src/components/shared/delete-modal.tsx
+++ b/src/components/shared/delete-modal.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { Trash } from "lucide-react";
 import { useDeleteAccount } from "@/hooks/profile/use-delete-account.hook";
+import { useTranslations } from "next-intl";
 
 /**
  * DeleteAccountModal component
@@ -14,6 +15,9 @@ import { useDeleteAccount } from "@/hooks/profile/use-delete-account.hook";
  */
 
 export default function DeleteAccountModal({ open, onOpenChange }: any) {
+    // Translation
+    const t = useTranslations("delete-modal");
+
     // Hook for deleting the user account
   const { mutate: deleteAccount, isPending } = useDeleteAccount();
 
@@ -27,10 +31,10 @@ export default function DeleteAccountModal({ open, onOpenChange }: any) {
         </DialogHeader>
 
         <p className="mt-2 text-xl font-semibold">
-          Are you sure you want to delete your account?
+          {t("delete-account-title")}
         </p>
         <p className="text-base text-maroon-500 font-normal">
-          This action is permanent and cannot be undone.
+          {t("delete-account-warning")}
         </p>
 
         <div className="mt-4 flex justify-center gap-2">
@@ -39,7 +43,7 @@ export default function DeleteAccountModal({ open, onOpenChange }: any) {
             className="text-base font-medium"
             onClick={() => onOpenChange(false)}
           >
-            Nope, not doing it
+            {t("cancel-delete")}
           </Button>
 
           <Button
@@ -48,7 +52,7 @@ export default function DeleteAccountModal({ open, onOpenChange }: any) {
             className="bg-red-600 text-base font-medium"
             onClick={() => deleteAccount(undefined, { onSuccess: () => onOpenChange(false) })}
           >
-            {isPending ? "Deleting..." : "Yes, delete"}
+            {isPending ? t("deleting") : t("confirm-delete")}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/shared/delete-modal.tsx
+++ b/src/components/shared/delete-modal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Trash } from "lucide-react";
+import { useDeleteAccount } from "@/hooks/profile/use-delete-account.hook";
+
+/**
+ * DeleteAccountModal component
+ * 
+ * Displays a modal dialog that asks the user to confirm account deletion.
+ * Uses a custom hook `useDeleteAccount` to handle the deletion logic.
+ * 
+ */
+
+export default function DeleteAccountModal({ open, onOpenChange }: any) {
+    // Hook for deleting the user account
+  const { mutate: deleteAccount, isPending } = useDeleteAccount();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white rounded-2xl p-8 max-w-md w-full text-center ">
+        <DialogHeader>
+          <DialogTitle className="mx-auto mb-6 w-24 h-24 rounded-full bg-[#2E2E3026] flex items-center justify-center border-8 border-gray-100">
+            <Trash size={40} className="text-gray-700" />
+          </DialogTitle>
+        </DialogHeader>
+
+        <p className="mt-2 text-xl font-semibold">
+          Are you sure you want to delete your account?
+        </p>
+        <p className="text-base text-maroon-500 font-normal">
+          This action is permanent and cannot be undone.
+        </p>
+
+        <div className="mt-4 flex justify-center gap-2">
+          <Button
+            variant="outline"
+            className="text-base font-medium"
+            onClick={() => onOpenChange(false)}
+          >
+            Nope, not doing it
+          </Button>
+
+          <Button
+            variant="default"
+            disabled={isPending}
+            className="bg-red-600 text-base font-medium"
+            onClick={() => deleteAccount(undefined, { onSuccess: () => onOpenChange(false) })}
+          >
+            {isPending ? "Deleting..." : "Yes, delete"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/shared/delete-modal.tsx
+++ b/src/components/shared/delete-modal.tsx
@@ -23,10 +23,10 @@ export default function DeleteAccountModal({ open, onOpenChange }: any) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-white rounded-2xl p-8 max-w-md w-full text-center ">
+      <DialogContent className="bg-white dark:bg-zinc-800 dark:border-zinc-800 rounded-2xl p-8 max-w-md w-full text-center ">
         <DialogHeader>
           <DialogTitle className="mx-auto mb-6 w-24 h-24 rounded-full bg-[#2E2E3026] flex items-center justify-center border-8 border-gray-100">
-            <Trash size={40} className="text-gray-700" />
+            <Trash size={40} className="text-gray-700 dark:text-gray-500" />
           </DialogTitle>
         </DialogHeader>
 

--- a/src/hooks/profile/use-change-password.hook.ts
+++ b/src/hooks/profile/use-change-password.hook.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { changePassword } from "@lib/actions/profile/change-password.action";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+// Custom hook to handle the change password process
+export function useChangePassword() {
+  return useMutation({
+    // Function that performs the password change request
+    mutationFn: changePassword,
+    // Triggered when the password is successfully changed
+    onSuccess: () => {
+      toast.success("Password updated successfully!");
+    },
+    // Triggered when the API call fails
+    onError: (error: any) => {
+      toast.error(error.message || "Something went wrong!");
+    },
+  });
+}

--- a/src/hooks/profile/use-delete-account.hook.ts
+++ b/src/hooks/profile/use-delete-account.hook.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { signOut } from "next-auth/react";
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/delete-account", {
+        method: "DELETE",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.message || "Failed to delete account");
+      }
+
+      return data;
+    },
+
+    onSuccess: () => {
+      toast.success("Account deleted");
+      signOut({ callbackUrl: "/login" });
+    },
+
+    onError: (err: any) => {
+      toast.error(err.message || "Something went wrong");
+    },
+  });
+}

--- a/src/hooks/profile/use-update-profile.hook.ts
+++ b/src/hooks/profile/use-update-profile.hook.ts
@@ -2,9 +2,13 @@
 
 import { ProfileFormValues } from "@lib/types/profile/profile";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 export function useUpdateProfile() {
+  // Translation
+  const t = useTranslations("profile");
+
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -19,15 +23,13 @@ export function useUpdateProfile() {
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(err.message || "Failed to update profile");
+        throw new Error(err.message || t("update-failed"));
       }
 
       return res.json();
     },
 
     onSuccess: (data) => {
-      toast.success("Profile updated successfully");
-
       queryClient.invalidateQueries({ queryKey: ["profile"] });
     },
 

--- a/src/hooks/profile/use-update-profile.hook.ts
+++ b/src/hooks/profile/use-update-profile.hook.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { ProfileFormValues } from "@lib/types/profile/profile";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: ProfileFormValues) => {
+      const res = await fetch("/api/update-profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(values),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.message || "Failed to update profile");
+      }
+
+      return res.json();
+    },
+
+    onSuccess: (data) => {
+      toast.success("Profile updated successfully");
+
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+    },
+
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -279,5 +279,21 @@
         "loaction-error": "يرجى اختيار موقع صالح على الخريطة",
         "updated-succ": "تم تحديث عنوانك بنجاح",
         "added-succ": "تمت إضافة عنوانك الجديد بنجاح"
+    },
+        "change-password": {
+        "old-password": "كلمة المرور الحالية",
+        "new-password": "كلمة المرور الجديدة",
+        "confirm-new-password": "تأكيد كلمة المرور الجديدة",
+        "updating": "جاري التحديث...",
+        "change-password": "تغيير كلمة المرور",
+        "password-updated-successfully": "تم تحديث كلمة المرور بنجاح!",
+        "failed-update-password": "فشل في تحديث كلمة المرور"
+    },
+    "profile": {
+        "logout": "تسجيل الخروج",
+        "my-account": "حسابي",
+        "change-password": "تغيير كلمة المرور",
+        "update-profile": "تحديث الملف الشخصي",
+        "account-settings": "تعديل الملف الشخصي"
     }
 }

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -304,7 +304,9 @@
         "delete-my-account": "احذف حسابي",
         "upload-photo": "رفع صورة",
         "upload-text": "يمكنك رفع صورة بصيغة .jpg أو .png أو .gif بحد أقصى 5 ميجابايت.",
-        "profile-updated-successfully": "تم تحديث الملف الشخصي بنجاح"
+        "profile-updated-successfully": "تم تحديث الملف الشخصي بنجاح",
+        "logged-out-successfully": "تم تسجيل الخروج بنجاح",
+        "logout-failed": "فشل تسجيل الخروج!"
     },
     "delete-modal": {
         "delete-account-title": "هل أنت متأكد أنك تريد حذف حسابك؟",
@@ -313,5 +315,4 @@
         "deleting": "جارٍ الحذف...",
         "confirm-delete": "نعم، احذف"
     }
-
 }

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -294,6 +294,24 @@
         "my-account": "حسابي",
         "change-password": "تغيير كلمة المرور",
         "update-profile": "تحديث الملف الشخصي",
-        "account-settings": "تعديل الملف الشخصي"
+        "account-settings": "تعديل الملف الشخصي",
+        "first-name": "الاسم الأول",
+        "last-name": "اسم العائلة",
+        "email": "البريد الإلكتروني",
+        "phone": "رقم الهاتف",
+        "gender": "النوع",
+        "save-changes": "حفظ التغييرات",
+        "delete-my-account": "احذف حسابي",
+        "upload-photo": "رفع صورة",
+        "upload-text": "يمكنك رفع صورة بصيغة .jpg أو .png أو .gif بحد أقصى 5 ميجابايت.",
+        "profile-updated-successfully": "تم تحديث الملف الشخصي بنجاح"
+    },
+    "delete-modal": {
+        "delete-account-title": "هل أنت متأكد أنك تريد حذف حسابك؟",
+        "delete-account-warning": "هذا الإجراء نهائي ولا يمكن التراجع عنه.",
+        "cancel-delete": "لا، لن أفعل",
+        "deleting": "جارٍ الحذف...",
+        "confirm-delete": "نعم، احذف"
     }
+
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -314,7 +314,9 @@
         "upload-photo": "Upload Photo",
         "upload-text": "You can upload a .jpg, .png, or .gif photo with max size of 5MB.", 
         "profile-updated-successfully": "Profile Updated Successfully..",
-         "update-failed": "Failed to update profile"
+         "update-failed": "Failed to update profile",
+         "logged-out-successfully": "Logged out Successfully..",
+         "logout-failed": "Logged out Failed!"
     },
     "delete-modal": {
         "delete-account-title": "Are you sure you want to delete your account?",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -303,7 +303,24 @@
         "my-account": "My Account",
         "change-password": "Change Password",
         "update-profile": "update profile",
-        "account-settings": "Account Settings"
-
+        "account-settings": "Account Settings",
+        "first-name": "First Name",
+        "last-name": "Last Name",
+        "email": "Email",
+        "phone": "Phone",
+        "gender": "Gender",
+        "save-changes": "Save Changes",
+        "delete-my-account": "Delete my account",
+        "upload-photo": "Upload Photo",
+        "upload-text": "You can upload a .jpg, .png, or .gif photo with max size of 5MB.", 
+        "profile-updated-successfully": "Profile Updated Successfully..",
+         "update-failed": "Failed to update profile"
+    },
+    "delete-modal": {
+        "delete-account-title": "Are you sure you want to delete your account?",
+        "delete-account-warning": "This action is permanent and cannot be undone.",
+        "cancel-delete": "Nope, not doing it",
+        "deleting": "Deleting...",
+        "confirm-delete": "Yes, delete"
     }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -288,5 +288,22 @@
         "loactions-error": "Please select a valid location on the map",
         "updated-succ": "Your Address updates successfully",
         "added-succ": "Your New Address added successfully"
+    },
+    "change-password": {
+        "old-password": "Old Password",
+        "new-password": "New Password",
+        "confirm-new-password": "Confirm New Password",
+        "updating": "Updating...",
+        "change-password": "Change Password",
+        "password-updated-successfully": "Password updated successfully!",
+        "failed-update-password": "Failed to update password"        
+    },
+    "profile": {
+        "logout": "Logout",
+        "my-account": "My Account",
+        "change-password": "Change Password",
+        "update-profile": "update profile",
+        "account-settings": "Account Settings"
+
     }
 }

--- a/src/lib/actions/profile/change-password.action.ts
+++ b/src/lib/actions/profile/change-password.action.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { JSON_HEADER } from "@lib/constants/shared.constant";
+import { ChangePasswordRequest } from "@lib/types/profile/change-password";
+import { getDecodeToken } from "@lib/utils/get-decode-token";
+
+// Function to change the user's password
+export async function changePassword(data: ChangePasswordRequest) {
+  // Get token from decode token function
+  const token = await getDecodeToken() 
+
+  // Send a PATCH request to the server to change the password
+  const res = await fetch(`${process.env.BASE_URL}auth/change-password`, {
+    method: "PATCH",
+    headers: {  
+      ...JSON_HEADER,
+      Authorization: `Bearer ${token?.accessToken}`,
+    },
+    body: JSON.stringify(data),
+  });
+  
+  // Check if the data is not ok 
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error?.message || "Failed to change password");
+  }
+
+  // Parse the response JSON payload after a successful request
+  const payload = await res.json();
+
+  // Return the server response payload
+  return payload;
+}

--- a/src/lib/actions/profile/profile.action.ts
+++ b/src/lib/actions/profile/profile.action.ts
@@ -1,0 +1,28 @@
+"use server";
+import { ProfileApiResponse, ProfileFormValues } from '@lib/types/profile/profile';
+import { getDecodeToken } from '@lib/utils/get-decode-token';
+
+/**
+ * Fetches the current user's profile data from the backend.
+ **/
+export async function getProfileData(): Promise<ProfileFormValues> {
+    // Get the decoded JWT token from cookies
+  const token = await getDecodeToken();
+
+    // Fetch profile data from the API with authentication
+  const res = await fetch(`${process.env.BASE_URL}auth/profile-data`, {
+        method: "GET",
+    headers: {
+      Authorization: `Bearer ${token?.accessToken}`,
+      cache: 'no-store', 
+    },
+    
+  });
+  // Handle errors from the API
+  if (!res.ok) throw new Error('Failed to fetch profile');
+
+  const data: ProfileApiResponse = await res.json();
+  
+    // Return the user object (profile data)
+  return data.user; 
+}

--- a/src/lib/schemas/profile/change-password.schema.ts
+++ b/src/lib/schemas/profile/change-password.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+// Define a validation schema for the Change Password form using Zod
+export const ChangePasswordFormSchema = z
+  .object({
+    password: z.string().min(1, "Current password is required"),
+    newPassword: z.string().min(6, "New password must be at least 6 characters"),
+    confirmNewPassword: z.string().min(1, "Please confirm your new password"),
+  })
+  // Custom validation to ensure new password and confirmation match
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    path: ["confirmNewPassword"],
+    message: "Passwords do not match",
+  });
+
+  // Define a TypeScript type inferred from the schema for form values
+  export type ChangePasswordValues = z.infer<typeof ChangePasswordFormSchema>;
+  

--- a/src/lib/schemas/profile/profile.schema.ts
+++ b/src/lib/schemas/profile/profile.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const profileSchema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  email: z.email("email-invalid").min(1, "email-required"),
+  phone: z.string().min(5, "Invalid phone number"),
+  gender: z.string(),
+  photo: z.string(),
+});
+
+export type ProfileSchema = z.infer<typeof profileSchema>;

--- a/src/lib/types/profile/change-password.d.ts
+++ b/src/lib/types/profile/change-password.d.ts
@@ -1,0 +1,11 @@
+import z from "zod";
+
+
+// Define TypeScript type for the change password request
+export type ChangePasswordRequest = {
+  password: string;
+  newPassword: string;
+};
+
+// Generic type to infer form input types from a Zod schema
+export type FormInput<T extends z.ZodType<any, any>> = z.infer<T>;

--- a/src/lib/types/profile/profile.d.ts
+++ b/src/lib/types/profile/profile.d.ts
@@ -1,0 +1,13 @@
+export type ProfileFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  gender: string;
+  phone: string;
+  photo: string;
+};
+
+export type ProfileApiResponse = {
+  message: string;
+  user: ProfileFormValues;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,31 +5,45 @@ import { routing } from "./i18n/routing";
 import { getToken } from "next-auth/jwt";
 
 const intlMiddleware = createMiddleware(routing);
-const PROTECTED_ROUTES = ["/wishlist", "/checkout", "/profile"];
+// Protected pages
+const PROTECTED_ROUTES = ["/checkout", "/dashboard", "/profile"];
+
+// Auth pages (public only)
+const AUTH_PAGES = ["/login", "/register"];
 
 export default async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
 
     // Extract locale
     const locale = pathname.split("/")[1] || routing.defaultLocale;
+    // Normalize path without locale
     const pathWithoutLocale = pathname.replace(`/${locale}`, "") || "/";
 
     // Check authentication
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
-    const isAuthPage = PROTECTED_ROUTES.includes(pathWithoutLocale);
+    
+  const isProtected = PROTECTED_ROUTES.includes(pathWithoutLocale);
+  const isAuthPage = AUTH_PAGES.includes(pathWithoutLocale);
 
-    // Authenticated user on auth page → redirect to home-page
-    if (token && isAuthPage) {
-        return NextResponse.redirect(new URL(`/${locale}/`, req.url));
-    }
+  // =============================
+  // 🚧 1) Auth user visiting login/register → redirect to home
+  // =============================
+  if (token && isAuthPage) {
+    return NextResponse.redirect(new URL(`/${locale}/`, req.url));
+  }
 
-    // Unauthenticated user on non-auth page → redirect to login
-    if (!token && isAuthPage) {
-        const loginUrl = new URL(`/${locale}/login`, req.url);
-        loginUrl.searchParams.set("callbackUrl", pathname);
-        return NextResponse.redirect(loginUrl);
-    }
+  // =============================
+  // 🔒 2) NON-auth user visiting protected route → redirect to login
+  // =============================
+  if (!token && isProtected) {
+    const loginUrl = new URL(`/${locale}/login`, req.url);
+    loginUrl.searchParams.set("callbackUrl", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
 
+  // =============================
+  // ✅ 3) Otherwise → allow access
+  // =============================
     return intlMiddleware(req);
 }
 


### PR DESCRIPTION
This PR introduces the Account Settings section in the user dashboard, allowing users to:

View and update their profile information (first name, last name, email, phone, and avatar).

Change their password securely via a dedicated form.

Delete their account through a confirmation modal.

Changes include:

Created ProfileForm component with form validation and pre-filled user data.

Implemented AvatarUpload component for profile picture updates.

Added DeleteAccountModal for account deletion confirmation.

Integrated Change Password link within the dashboard.

Server-side function getProfileData to fetch authenticated user data.

React Query hooks (useUpdateProfile, useDeleteAccount) for API interactions.

Styled components using Tailwind CSS for a consistent dashboard UI.

Benefits:

Users can manage their account settings easily from the dashboard.

Ensures security by requiring confirmation for sensitive actions (delete account, change password).

Improves user experience with a clean, responsive interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account settings UI with editable profile form, avatar upload, and profile sidebar/navigation
  * Change password flow and confirmation modal for account deletion
  * New profile layout and dashboard pages
  * Arabic and English translation strings added

* **Chores**
  * Updated auth routing behavior with clearer handling of protected pages and auth pages (login/register)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->